### PR TITLE
Filter modes which don't match entity/country/region if present

### DIFF
--- a/src/lib/modes.js
+++ b/src/lib/modes.js
@@ -163,7 +163,12 @@ const AllSegments = Object.keys(BandPlans.bands).reduce((segments, band) => {
 }, [])
 
 export function modeForFrequency(frequency, { ituRegion, countryCode, entityPrefix } = {}) {
-  const segments = AllSegments.filter(segment => segment.mhz[0] <= frequency && segment.mhz[1] >= frequency)
+  const segments = AllSegments.filter(segment => (
+    (segment.mhz[0] <= frequency && segment.mhz[1] >= frequency) &&
+    (!entityPrefix || Object.keys(segment.entities).length === 0 || segment.entities[entityPrefix]) &&
+    (!countryCode || Object.keys(segment.countries).length === 0 || segment.countries[countryCode]) &&
+    (!ituRegion || Object.keys(segment.regions).length === 0 || segment.regions[ituRegion])
+    ))
   const sortedSegments = segments.sort((a, b) => {
     if (entityPrefix && !a.entities[entityPrefix] && b.entities[entityPrefix]) return 1
     if (entityPrefix && a.entities[entityPrefix] && !b.entities[entityPrefix]) return -1


### PR DESCRIPTION
I did try to add logic to sort method to handle this at first, with those without specific entity/country/region taking preference, but resulted in a non-transitive comparison, which then had other odd behaviour.

I realised that filtering non-matching parts of band much simpler solution, and leaving sort as is, leaves it to pick matching entity/country/regions more preferable to those mode lines missing them.