### PR TITLE
Add 4m band plan

### DIFF
--- a/src/data/bandPlans.json
+++ b/src/data/bandPlans.json
@@ -3,6 +3,7 @@
     { "url": "https://www.iaru-r2.org/en/reference/band-plans/" },
     { "url": "https://www.arrl.org/band-plan" },
     { "url": "https://www.arrl.org/news/view/updated-arrl-us-amateur-radio-bands-charts-now-available" }
+    { "url": "https://rsgb.org/main/operating/band-plans/vhf-uhf/70mhz-band/"}
   ],
   "bands": {
     "160m": {
@@ -136,6 +137,16 @@
         { "name": "FT4", "mhz": [50318, 50321], "mode": "FT4", "priority": 100 },
         { "name": "FT8", "mhz": [50323, 50326], "mode": "FT8", "priority": 100 },
         { "name": "Australia", "mhz": [50000, 54000], "mode": null, "countries": ["au"] }
+      ]
+    },
+    "4m": {
+      "mhz": [70000, 70500],
+      "segments": [
+        { "name": "Phone", "mhz": [70100, 70294], "mode": "SSB", "submode": "USB" },
+        { "name": "FM", "mhz": [70294, 70500], "mode": "FM" },
+        { "name": "AM", "mhz": [70257, 70263], "mode": "AM", "priority": 100 },
+        { "name": "FT8", "mhz": [70100, 70103], "mode": "FT8", "priority": 100 },
+        { "name": "FT8", "mhz": [70154, 70157], "mode": "FT8", "priority": 100 }
       ]
     },
     "2m": {


### PR DESCRIPTION
Hi,

Following a brief discussion between Rich M7GET, Steve M1SDH and myself on the OARC Discord, I thought I would put in a PR for adding a 4m band blan to PoLo (and any other software that uses `lib-operation-data`).

The challenge however is that the 4m band allocation varies a lot between countries (see [Wikipedia](https://en.wikipedia.org/wiki/4-metre_band#Countries_in_which_operation_is_permitted)) and there is almost no allocation for this band outside Europe.

I have put in a first attempt, which matches the UK band plan, but I'm not clear on exactly what the `countries` field does and whether I should be using it - it currently seems to just be used to remove all default modes on HF segments for Australian users. Can I use this to set up completely different segments per country on 4m?

If you're happy with the RSGB 4m band plan being in there and available to all, this PR should be enough already, but if you would like me to refine it to include the country-by-country allocations, and/or mask it out to make it clearer that there is no allocation in other countries, could you please suggest how the `countries` field should be used for this?

Thanks